### PR TITLE
Tolerance for more OO ReadLine implementations, e.g. Term::ReadLine::…

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+0.93: 18 Jun 2015
+
+- Tolerance for more OO Readline implementations,
+  e.g. Term::ReadLine::Perl5
+
+
 0.92: 03 Feb 2012
 
 - Cleanups and fixes for Debian packaging by Boris Peck.

--- a/META.yml
+++ b/META.yml
@@ -10,7 +10,7 @@ configure_requires:
     ExtUtils::MakeMaker:  0
 build_requires:
     ExtUtils::MakeMaker:  0
-requires:  {}
+requires:  {Scalar::Util}
 no_index:
     directory:
         - t

--- a/lib/Term/ShellUI.pm
+++ b/lib/Term/ShellUI.pm
@@ -9,11 +9,12 @@ package Term::ShellUI;
 
 use strict;
 
+use Scalar::Util qw(reftype);
 use Term::ReadLine ();
 use Text::Shellwords::Cursor;
 
 use vars qw($VERSION);
-$VERSION = '0.92';
+$VERSION = '0.92_01';
 
 
 =head1 NAME
@@ -754,7 +755,11 @@ sub new
     # $attrs->{history_word_delimiters} = " \t\n".$self->{token_chars};
     $attrs->{completion_function} = sub { completion_function($self, @_); };
 
-    $self->{OUT} = $self->{term}->OUT || \*STDOUT;
+    if (reftype($self->{term}) == 'HASH') {
+	$self->{OUT} = $self->{term}->{OUT} || \*STDOUT;
+    } else {
+	$self->{OUT} = $self->{term}->OUT || \*STDOUT;
+    }
     $self->{prevcmd} = "";  # cmd to run again if user hits return
 
     @{$self->{eof_exit_hooks}} = ();


### PR DESCRIPTION
There is a problem with current versions of Term::ReadLine::Perl5 and Term::ShellUI.  See https://github.com/rocky/p5-Term-ReadLine-Perl5/issues/8 which references problem when someone tried to use this with kpci. Thanks.